### PR TITLE
Combine CommitResources for CBooRenderer::UpdateAreaUniforms.

### DIFF
--- a/Runtime/Graphics/CBooRenderer.cpp
+++ b/Runtime/Graphics/CBooRenderer.cpp
@@ -796,14 +796,17 @@ void CBooRenderer::UpdateAreaUniforms(int areaIdx, EWorldShadowMode shadowMode, 
     if (shadowMode == EWorldShadowMode::BallOnWorldShadow || shadowMode == EWorldShadowMode::BallOnWorldIds)
       continue;
 
-    for (auto it = item.x10_models.begin(); it != item.x10_models.end(); ++it) {
-      CBooModel* model = *it;
-      if (model->TryLockTextures()) {
-        if (activateLights)
-          ActivateLightsForModel(&item, *model);
-        model->UpdateUniformData(flags, nullptr, nullptr, bufIdx);
+    CGraphics::CommitResources([&](boo::IGraphicsDataFactory::Context& ctx) {
+      for (auto it = item.x10_models.begin(); it != item.x10_models.end(); ++it) {
+        CBooModel* model = *it;
+        if (model->TryLockTextures()) {
+          if (activateLights)
+            ActivateLightsForModel(&item, *model);
+          model->UpdateUniformData(flags, nullptr, nullptr, bufIdx, &ctx);
+        }
       }
-    }
+      return true;
+    } BooTrace);
   }
 }
 

--- a/Runtime/Graphics/CModel.hpp
+++ b/Runtime/Graphics/CModel.hpp
@@ -177,7 +177,7 @@ private:
   boo::ObjToken<boo::ITexture> m_lastDrawnOneTexture;
   boo::ObjToken<boo::ITextureCubeR> m_lastDrawnReflectionCube;
 
-  ModelInstance* PushNewModelInstance(int sharedLayoutBuf = -1);
+  ModelInstance* PushNewModelInstance(int sharedLayoutBuf = -1, boo::IGraphicsDataFactory::Context* ctx = nullptr);
   void DrawAlphaSurfaces(const CModelFlags& flags) const;
   void DrawNormalSurfaces(const CModelFlags& flags) const;
   void DrawSurfaces(const CModelFlags& flags) const;
@@ -217,7 +217,8 @@ public:
   void Touch(int shaderIdx);
   void VerifyCurrentShader(int shaderIdx);
   boo::ObjToken<boo::IGraphicsBufferD> UpdateUniformData(const CModelFlags& flags, const CSkinRules* cskr,
-                                                         const CPoseAsTransforms* pose, int sharedLayoutBuf = -1);
+                                                         const CPoseAsTransforms* pose, int sharedLayoutBuf = -1,
+                                                         boo::IGraphicsDataFactory::Context* ctx = nullptr);
   void DrawAlpha(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose);
   void DrawNormal(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose);
   void Draw(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose);


### PR DESCRIPTION
This shares the IGraphicsDataFactory::Context over many functions, to avoid
the overhead of calling CGraphics::CommitResources multiple times.